### PR TITLE
adding the sender phone example project 

### DIFF
--- a/RELEASE-NOTES-v1.4.3.md
+++ b/RELEASE-NOTES-v1.4.3.md
@@ -1,0 +1,18 @@
+# Release Notes - Version 1.4.3
+
+## What's New
+
+- Version bump to 1.4.3
+- Minor improvements and bug fixes
+
+## Changes
+
+- Updated package version to 1.4.3
+
+## Bug Fixes
+
+- General stability improvements
+
+---
+
+For full documentation and examples, visit: https://github.com/CloudContactAI/CCAI.NET

--- a/RELEASE-NOTES-v1.4.4.md
+++ b/RELEASE-NOTES-v1.4.4.md
@@ -1,0 +1,15 @@
+# Release Notes - Version 1.4.4
+
+## New Features
+- Added sms-sender-phone example project demonstrating consistent sender phone usage
+- Added Phone and PhoneService entities to enable the API to pull the existing phone numbers from their CCAI account.
+- Added support for the SMSService to support passing in a senderPhone.
+- Enhanced PhoneService integration for SMS campaigns
+
+## Improvements
+- Updated project templates to support .NET 8.0 compatibility
+- Improved example project structure and organization
+
+## Bug Fixes
+- Fixed multiple entry point compilation errors in examples project
+- Resolved .NET framework targeting issues

--- a/examples/CCAI.NET.Examples.csproj
+++ b/examples/CCAI.NET.Examples.csproj
@@ -26,6 +26,7 @@
     <Compile Remove="sms-custom-data-test/Program.cs" />
     <Compile Remove="webhook-server/Program.cs" />
     <Compile Remove="sms-sender/Program.cs" />
+    <Compile Remove="sms-sender-phone/Program.cs" />
   </ItemGroup>
 
 </Project>

--- a/examples/sms-sender-phone/Program.cs
+++ b/examples/sms-sender-phone/Program.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Threading.Tasks;
+using CCAI.NET;
+using CCAI.NET.SMS;
+using DotNetEnv;
+
+namespace SmsSenderPhone;
+
+public class Program
+{
+    public static async Task Main(string[] args)
+    {
+        Env.Load();
+        
+        var config = new CCAIConfig
+        {
+            ClientId = Environment.GetEnvironmentVariable("CCAI_CLIENT_ID") ?? throw new InvalidOperationException("CCAI_CLIENT_ID not found"),
+            ApiKey = Environment.GetEnvironmentVariable("CCAI_API_KEY") ?? throw new InvalidOperationException("CCAI_API_KEY not found"),
+            UseTestEnvironment = true
+        };
+        
+        using var ccai = new CCAIClient(config);
+        
+        try
+        {
+            // Get list of available phones
+            Console.WriteLine("Fetching available phones...");
+            var phones = await ccai.Phone.ListAsync();
+            
+            if (phones == null || phones.Count == 0)
+            {
+                Console.WriteLine("No phones available for sending SMS");
+                return;
+            }
+            
+            // Use the first available phone
+            var senderPhone = phones[0].PhoneNumber;
+            Console.WriteLine($"Using sender phone: {senderPhone}");
+            
+            var recipientPhone = Environment.GetEnvironmentVariable("TEST_PHONE_NUMBER") ?? throw new InvalidOperationException("TEST_PHONE_NUMBER not found");
+            var firstName = Environment.GetEnvironmentVariable("TEST_FIRST_NAME") ?? "John";
+            var lastName = Environment.GetEnvironmentVariable("TEST_LAST_NAME") ?? "Doe";
+            
+            // Send first SMS message
+            Console.WriteLine("Sending first SMS message...");
+            var response1 = await ccai.SMS.SendSingleAsync(
+                firstName: firstName,
+                lastName: lastName,
+                phone: recipientPhone,
+                message: "Hello ${FirstName}! This is your first message from CCAI.NET at " + DateTime.Now.ToString("HH:mm:ss"),
+                title: "First SMS Test",
+                senderPhone: senderPhone
+            );
+            
+            Console.WriteLine("First SMS sent successfully!");
+            Console.WriteLine($"Status: {response1.Status}");
+            
+            // Wait a moment between messages
+            await Task.Delay(2000);
+            
+            // Send second SMS message using the same sender phone
+            Console.WriteLine("Sending second SMS message...");
+            var response2 = await ccai.SMS.SendSingleAsync(
+                firstName: firstName,
+                lastName: lastName,
+                phone: recipientPhone,
+                message: "Hello ${FirstName}! This is your second message from the same phone at " + DateTime.Now.ToString("HH:mm:ss"),
+                title: "Second SMS Test",
+                senderPhone: senderPhone
+            );
+            
+            Console.WriteLine("Second SMS sent successfully!");
+            Console.WriteLine($"Status: {response2.Status}");
+            Console.WriteLine($"Both messages sent using sender phone: {senderPhone}");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error: {ex.Message}");
+            if (ex.InnerException != null)
+            {
+                Console.WriteLine($"Inner error: {ex.InnerException.Message}");
+            }
+        }
+    }
+}

--- a/examples/sms-sender-phone/sms-sender-phone.csproj
+++ b/examples/sms-sender-phone/sms-sender-phone.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/CCAI.NET/CCAI.NET.csproj" />
+    <PackageReference Include="DotNetEnv" Version="3.1.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/CCAI.NET/CCAI.NET.csproj
+++ b/src/CCAI.NET/CCAI.NET.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <PackageId>CloudContactAI.CCAI.NET</PackageId>
-    <Version>1.4.2</Version>
+    <Version>1.4.4</Version>
     <Authors>CloudContactAI LLC</Authors>
     <Company>CloudContactAI LLC</Company>
     <Description>C# client for CloudContactAI API with SMS, MMS, Email, and Webhook support. Enhanced webhook support with new CloudContact event format, environment variable configuration, and comprehensive examples.</Description>
@@ -15,7 +15,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RepositoryUrl>https://github.com/CloudContactAI/CCAI.NET</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/../../RELEASE-NOTES-v1.4.2.md"))</PackageReleaseNotes>
+    <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/../../RELEASE-NOTES-v1.4.4.md"))</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/CloudContactAI/CCAI.NET</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
The new sample project demonstrates how to grab the phone numbers associated with your CCAI client, and then to use one of the phone numbers to specify the senderPhone for multiple messages. If you don't specify the senderPhone, then CCAI will pick from the phone number pool.